### PR TITLE
Fix can't get mimikyu data issue

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -948,7 +948,7 @@
     "komala": "Komala",
     "turtonator": "Turtonator",
     "togedemaru": "Togedemaru",
-    "mimikyu": "Mimikyu",
+    "mimikyu-disguised": "Mimikyu",
     "bruxish": "Bruxish",
     "drampa": "Drampa",
     "dhelmise": "Dhelmise",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -948,7 +948,7 @@
     "komala": "ネッコアラ",
     "turtonator": "バクガメス",
     "togedemaru": "トゲデマル",
-    "mimikyu": "ミミッキュ",
+    "mimikyu-disguised": "ミミッキュ",
     "bruxish": "ハギギシリ",
     "drampa": "ジジーロン",
     "dhelmise": "ダダリン",

--- a/locales/zhHant.json
+++ b/locales/zhHant.json
@@ -953,7 +953,7 @@
     "komala": "樹枕尾熊",
     "turtonator": "爆焰龜獸",
     "togedemaru": "托戈德瑪爾",
-    "mimikyu": "謎擬Ｑ",
+    "mimikyu-disguised": "謎擬Ｑ",
     "bruxish": "磨牙彩皮魚",
     "drampa": "老翁龍",
     "dhelmise": "破破舵輪",


### PR DESCRIPTION
Issue:
Select mimikyu but API can't find the data, cause the UI hangs on loading status.

Root cause:
The API uses "mimikyu-disguised" as the name of "mimikyu"

Fix:
Change the name to "mimikyu-disguised"